### PR TITLE
Cross Origin Resource Sharing tests

### DIFF
--- a/src/main/java/net/continuumsecurity/behaviour/ICors.java
+++ b/src/main/java/net/continuumsecurity/behaviour/ICors.java
@@ -1,0 +1,6 @@
+package net.continuumsecurity.behaviour;
+
+public interface ICors {
+	void makeCorsRequest(String path, String origin);
+	String getAccessControlAllowOriginHeader();
+}

--- a/src/main/java/net/continuumsecurity/jbehave/JUnitStoryRunner.java
+++ b/src/main/java/net/continuumsecurity/jbehave/JUnitStoryRunner.java
@@ -85,7 +85,8 @@ public class JUnitStoryRunner extends BaseStoryRunner {
                 new NessusScanningSteps(),
                 new SSLyzeSteps(),
                 new AppScanningSteps(),
-                new WrapUpScanSteps()
+                new WrapUpScanSteps(),
+                new CorsSteps()
                 );
     }
 

--- a/src/main/java/net/continuumsecurity/steps/CorsSteps.java
+++ b/src/main/java/net/continuumsecurity/steps/CorsSteps.java
@@ -1,0 +1,42 @@
+package net.continuumsecurity.steps;
+
+import net.continuumsecurity.*;
+import net.continuumsecurity.behaviour.ICors;
+import net.continuumsecurity.web.Application;
+
+import org.jbehave.core.annotations.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class CorsSteps {
+    public Application app;
+    
+    public Application getWebApplication() {
+        return app;
+    }
+
+    @BeforeStories
+    public void beforeStories() {
+        Config.getInstance().initialiseTables();
+    }
+
+    @When("the path <path> is requested with the HTTP method GET with the 'Origin' header set to <origin>")
+    public void corsRequest(@Named("path") String path, @Named("origin") String origin) {
+    	((ICors) app).makeCorsRequest(path, origin);
+    }
+    
+    @Then("the returned 'Access-Control-Allow-Origin' header has the value <origin>")
+    public void checkAccessControlAllowOriginHeader(@Named("origin") String origin) {
+    	String returnedHeader = ((ICors) app).getAccessControlAllowOriginHeader();
+    	
+    	assertThat("The returned Access-Control-Allow-Origin header equals the Origin", returnedHeader, equalTo(origin));
+    }
+
+    @Then("the header 'Access-Control-Allow-Origin' header is not returned")
+    public void checkAccessControlAllowOriginHeader() {
+    	String returnedHeader = ((ICors) app).getAccessControlAllowOriginHeader();
+    	
+    	assertThat("The header 'Access-Control-Allow-Origin' header was not returned", returnedHeader, equalTo(null));
+    }
+}

--- a/src/main/stories/cors.story
+++ b/src/main/stories/cors.story
@@ -1,0 +1,24 @@
+Narrative: 
+In order to reduce the risk of Cross Site Request Forgery
+As a system owner
+I want to verify that the application does not allow the browser to perform requests outside of the allowed origins
+
+Meta: @story cors
+
+Scenario: Permit allowed origins to make CORS requests
+Meta: @id cors_successful_from_allowed_origins @cwe-942-cors
+Given a new browser or client instance
+And the client/browser is configured to use an intercepting proxy
+When the path <path> is requested with the HTTP method GET with the 'Origin' header set to <origin>
+Then the returned 'Access-Control-Allow-Origin' header has the value <origin>
+Examples:
+tables/allowed.cors.requests.table
+
+Scenario: Forbid disallowed origins from making CORS requests
+Meta: @id cors_unsuccessful_from_disallowed_origins @cwe-942-cors
+Given a new browser or client instance
+And the client/browser is configured to use an intercepting proxy
+When the path <path> is requested with the HTTP method GET with the 'Origin' header set to <origin>
+Then the header 'Access-Control-Allow-Origin' header is not returned
+Examples:
+tables/disallowed.cors.requests.table

--- a/src/main/stories/tables/allowed.cors.requests.table
+++ b/src/main/stories/tables/allowed.cors.requests.table
@@ -1,0 +1,1 @@
+|path				|origin															|

--- a/src/main/stories/tables/disallowed.cors.requests.table
+++ b/src/main/stories/tables/disallowed.cors.requests.table
@@ -1,0 +1,1 @@
+|path				|origin															|


### PR DESCRIPTION
Tests whether CORS access is being properly enforced, using a given set of allowed and disallowed request origins and endpoints.

The 'ICors' interface must be implemented by the 'Application' subclass.