### PR TITLE
Initial Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+_Store*
+.idea/*
+zap/tmp
+.git
+build/
+.gradle
+*.iml
+*.output
+log4j.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use OpenJDK 8
+FROM openjdk:8-jdk
+
+ENV URL "https:\/\/localhost:8080\/"
+ENV TAGS "@cwe-319-auth"
+ENV TAGS_SKIP "~@skip"
+
+# Set a sensible server directory.
+WORKDIR /home/bdd-security
+
+# Add the directory
+ADD . .
+
+# run gradle
+RUN ./gradlew buildIt
+
+# Execute gradle tests
+CMD sed -E -i "s/<baseUrl>.+<\/baseUrl>/<baseUrl>$URL<\/baseUrl>/" config.xml && ./gradlew -Dcucumber.options="--tags ${TAGS} --tags ${TAGS_SKIP}"

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ task generateReportTask() {
     }
 }
 
+task buildIt() {
+    dependsOn assemble, compileTestJava, cleanReports
+}
+
 test {
     systemProperties = System.properties
     dependsOn assemble, compileTestJava, cleanReports


### PR DESCRIPTION
This commit adds the initial Dockerfile, .dockerignore and an updated build.gradle task named BuildIt to be included in the docker image. This pull request addresses feature #68 .

What still has to be added is to extract the relevant artifacts from the docker container.

I have some ideas on how to do that but would be interested in getting feedback from others.

Also, there may be a better way to solve the substitution of baseUrls as opposed to using sed.

Let me know your thoughts. I'll work on the extracting the relevant build artifacts first and will create another pull request for this.