### PR TITLE
Update selenium dependencies to v3.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,8 +115,8 @@ dependencies {
     testCompile 'org.glassfish.jersey.media:jersey-media-moxy:2.25.1'
     testCompile 'junit:junit-dep:4.11'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile ('org.seleniumhq.selenium:selenium-java:3.4.0') { exclude group: 'junit' }
-    testCompile 'org.seleniumhq.selenium:selenium-api:3.4.0'
+    testCompile ('org.seleniumhq.selenium:selenium-java:3.5.3') { exclude group: 'junit' }
+    testCompile 'org.seleniumhq.selenium:selenium-api:3.5.3'
     testCompile 'log4j:log4j:1.2.17'
     testCompile 'args4j:args4j:2.0.16'
     testCompile 'commons-configuration:commons-configuration:1.8'


### PR DESCRIPTION
Hi,
I had an issue with bdd-security v2.2 and selenium. 
When I launched BDD-Security v2.2 I had an error : 

java.lang.NoClassDefFoundError: org/openqa/selenium/remote/JsonToBeanConverter 

To fix this issue I just upgrade the version of the Selenium dependencies. I mooved to selenium v3.5.3. (was 3.4.0)
I tested it and it runs perfectly.