### PR TITLE
Update the ssl feature, maxDepth configuration and fix bug of the input password regex

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -15,9 +15,16 @@
     <!-- A Java class to hold the Selenium steps to test the application in depth. Optionally required for in-depth authn/z and session management testing. -->
     <class>net.continuumsecurity.examples.ropeytasks.RopeyTasksApplication</class>
 
+    <!-- In order to install sslyze on a Linux system, these steps must be followed
+	apt-get update
+	apt-get install python-pip
+	pip install sslyze
+    -->
     <sslyze>
-        <path>/opt/sslyze/sslyze_cli.py</path>
-        <option>--regular</option>
+        <path>sslyze</path>
+	<option>--regular</option>
+        <targetHost>www.continuumsecurity.net</targetHost>
+        <targetPort>443</targetPort>
     </sslyze>
 
     <!-- Optional names of the session ID cookies for session management testing. -->
@@ -31,7 +38,8 @@
 
     <scanner>
         <ignoreUrl>.*logout.*</ignoreUrl>
-        <spiderUrl>baseUrl</spiderUrl>
+	<spiderUrl>baseUrl</spiderUrl>
+	<maxDepth>5</maxDepth>
     </scanner>
 
     <!-- An upstream proxy through which all HTTP traffic must pass before hitting the target

--- a/src/test/java/net/continuumsecurity/Config.java
+++ b/src/test/java/net/continuumsecurity/Config.java
@@ -92,6 +92,12 @@ public class Config {
         return spiderUrls;
     }
 
+    public int getMaxDepth() {
+        String portAsString = validateAndGetString("scanner.maxDepth");
+        if (portAsString != null && portAsString.length() > 0) return Integer.parseInt(portAsString);
+        return 10;
+    }
+
     public String getClassName() {
         return validateAndGetString("class");
     }
@@ -209,6 +215,16 @@ public class Config {
         String portAsString = validateAndGetString("upstreamProxy.port");
         if (portAsString != null && portAsString.length() > 0) return Integer.parseInt(portAsString);
         return 80;
+    }
+
+    public String getSslHost(){
+        return validateAndGetString("sslyze.targetHost");
+    }
+
+    public int getSslPort(){
+        String portAsString =  validateAndGetString("sslyze.targetPort");
+        if (portAsString != null && portAsString.length() > 0) return Integer.parseInt(portAsString);
+        return 443;
     }
 
     public List<String> getSessionIDs() {

--- a/src/test/java/net/continuumsecurity/steps/AppScanningSteps.java
+++ b/src/test/java/net/continuumsecurity/steps/AppScanningSteps.java
@@ -365,7 +365,8 @@ public class AppScanningSteps {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            getSpider().setMaxDepth(10);
+	    int maxDepth = Config.getInstance().getMaxDepth();
+            getSpider().setMaxDepth(maxDepth);
             getSpider().setThreadCount(10);
             for (String url : Config.getInstance().getSpiderUrls()) {
                 if (url.equalsIgnoreCase("baseurl")) url = Config.getInstance().getBaseUrl();

--- a/src/test/java/net/continuumsecurity/steps/SSLyzeSteps.java
+++ b/src/test/java/net/continuumsecurity/steps/SSLyzeSteps.java
@@ -17,10 +17,14 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
  */
 public class SSLyzeSteps {
     final static String OUTFILENAME = "sslyze.output";
+    static String host=null;
+    static int port=443;
 
-    @When("^the SSLyze command is run against the host (.*) on port (\\d+)$")
-    public void runSSLTestsOnSecureBaseUrl(String host, int port) throws IOException {
+    @When("the SSLyze command is run against the application")
+    public void runSSLTestsOnSecureBaseUrl() throws IOException {
         if (!World.getInstance().isSslRunCompleted()) {
+            port = Config.getInstance().getSslPort();
+            host= Config.getInstance().getSslHost();
             JSSLyze jSSLLyze = new JSSLyze(Config.getInstance().getSSLyzePath(), OUTFILENAME);
             jSSLLyze.execute(Config.getInstance().getSSLyzeOption(),host,port);
             World.getInstance().setjSSLyze(jSSLLyze);

--- a/src/test/java/net/continuumsecurity/steps/WebApplicationSteps.java
+++ b/src/test/java/net/continuumsecurity/steps/WebApplicationSteps.java
@@ -245,7 +245,7 @@ public class WebApplicationSteps {
 
     @Given("the HTTP request-response containing the login form")
     public void findResponseWithLoginform() throws UnsupportedEncodingException {
-        String regex = "(?i)input[\\s\\w=:'\"]*type\\s*=\\s*['\"]password['\"]";
+        String regex = "(?i)input[\\s\\w=:'-\"]*type\\s*=\\s*['\"]password['\"]";
         List<HarEntry> responses = getProxy().getHistory();
         responses = getProxy().findInResponseHistory(regex);
         if (responses == null || responses.size() == 0)

--- a/src/test/resources/features/ssl.feature
+++ b/src/test/resources/features/ssl.feature
@@ -3,7 +3,7 @@ Feature: SSL
   Ensure that the SSL configuration of the service is robust
 
   Background: Run the SSLyze command only once for all features
-    When the SSLyze command is run against the host www.continuumsecurity.net on port 443
+    When the SSLyze command is run against the application
 
   @iriusrisk-ssl_crime
   Scenario: Disable SSL deflate compression in order to mitigate the risk of the CRIME attack


### PR DESCRIPTION
 - the target host and port for ssl are now configurable through the config.xml file
 - add some instructions for the installation of sslyze
 - add feature to allow configuration of the maxDepth for zap
 - Add '-' to the regex to match input of this type : <input class="form-control" id="password" name="password" type="password">