### PR TITLE
Fixes #96 - Settings through environment variables

### DIFF
--- a/src/test/java/net/continuumsecurity/Config.java
+++ b/src/test/java/net/continuumsecurity/Config.java
@@ -132,8 +132,14 @@ public class Config {
         }
     }
 
+    /*
+        If value is defined as a system environment variable, then return its value.
+        If not, then search for it in the config file
+    */
     private String validateAndGetString(String value) {
-        String ret = getXml().getString(value);
+        String ret = System.getenv(value);
+        if (ret != null) return ret;
+        ret = getXml().getString(value);
         if (ret == null) throw new RuntimeException(value+" not defined in config.xml");
         return ret;
     }


### PR DESCRIPTION
Fixes #96 
All settings in config.xml can be set using environment variables.
If the environment variable does not exist, then the settings would be read from the config.xml.

